### PR TITLE
Add render dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ set(PROJECT_SOURCES
     src/main.cpp
     src/mainwindow.cpp
     src/mainwindow.h
+    src/render_dialog.cpp
+    src/render_dialog.h
     src/vgm.cpp
     src/vgm.h
     src/wave_writer.cpp

--- a/src/lib/layout_macros.h
+++ b/src/lib/layout_macros.h
@@ -175,5 +175,14 @@
     form__label_wptr(LEFT_TEXT, new RIGHT)
 
 
+/// Add a QSplitter which pretends to be a QLayout (is assigned to l).
+#define l__splitl(QSPLITTER, ...) \
+    auto * parentL = l; \
+    auto * l = new QSPLITTER; \
+    parentL->addWidget(l VA_COMMA(__VA_ARGS__)); \
+    \
+    require_semicolon
+
+
 #define append_stretch(...) \
     l->addStretch(__VA_ARGS__)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -574,6 +574,9 @@ public:
 
         setWindowFilePath(_file_path);
         // setWindowModified(false);
+
+        // Disable render button when no file is open.
+        _render->setDisabled(_backend.channels().empty());
     }
 
     void move_up() {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,4 +1,5 @@
 #include "mainwindow.h"
+#include "render_dialog.h"
 #include "gui_app.h"
 #include "lib/defer.h"
 #include "lib/layout_macros.h"
@@ -28,7 +29,6 @@
 #include <QFileInfo>
 #include <QTextCursor>
 #include <QTextDocument>
-#include <QTimer>
 
 #include <algorithm>  // std::rotate
 #include <set>
@@ -420,7 +420,6 @@ static QString errors_to_html(QString const& prefix, std::vector<QString> const&
 class MainWindowImpl final : public MainWindow {
 public:
     QErrorMessage _error_dialog{this};
-    QTimer _render_status_timer;
 
     ChipsModel _chips_model;
     ChannelsModel _channels_model;
@@ -528,16 +527,10 @@ public:
         connect(_move_up, &QPushButton::clicked, this, &MainWindowImpl::move_up);
         connect(_move_down, &QPushButton::clicked, this, &MainWindowImpl::move_down);
 
-        _render_status_timer.setInterval(200);
-        connect(
-            &_render_status_timer, &QTimer::timeout,
-            this, &MainWindowImpl::update_render_status);
-
         if (!path.isEmpty()) {
-            // Calls update_render_status().
             load_path(std::move(path));
         } else {
-            update_render_status();
+            update_file_status();
         }
     }
 
@@ -559,7 +552,7 @@ public:
         }
     }
 
-    void reload_title() {
+    void update_file_status() {
         _file_title = (!_file_path.isEmpty())
             ? QFileInfo(_file_path).fileName()
             : QString();
@@ -636,21 +629,11 @@ public:
             // returning).
         }
 
-        _render_status_timer.start();
-        update_render_status();
-    }
-
-    bool update_render_status() {
-        bool const is_rendering = _backend.is_rendering();
-        _open->setDisabled(is_rendering);
-        _render->setDisabled(is_rendering || _backend.channels().empty());
-
-        // TODO show per-channel status and errors somewhere?
-
-        if (!is_rendering) {
-            _render_status_timer.stop();
+        if (_backend.is_rendering()) {
+            auto render = new RenderDialog(&_backend, this);
+            render->setAttribute(Qt::WA_DeleteOnClose);
+            render->show();
         }
-        return is_rendering;
     }
 
 // impl QWidget
@@ -719,8 +702,7 @@ StateTransaction::~StateTransaction() noexcept(false) {
 
     // Window title
     if (e & E::FileReplaced) {
-        _win->reload_title();
-        _win->update_render_status();
+        _win->update_file_status();
     }
 
     // Chips list

--- a/src/render_dialog.cpp
+++ b/src/render_dialog.cpp
@@ -1,0 +1,326 @@
+#include "render_dialog.h"
+#include "mainwindow.h"
+#include "backend.h"
+#include "lib/layout_macros.h"
+#include "lib/release_assert.h"
+
+#include <QBoxLayout>
+#include <QLabel>
+#include <QPlainTextEdit>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QSplitter>
+
+#include <QTreeView>
+#include <QAbstractTableModel>
+
+#include <QDebug>
+#include <QFutureWatcher>
+
+static QString format_duration(int seconds) {
+    return QStringLiteral("%1:%2")
+        .arg(seconds / 60, 0, 10, QLatin1Char('0'))
+        .arg(seconds % 60, 2, 10, QLatin1Char('0'));
+}
+
+struct ProgressState {
+    int curr;
+    int max;
+    bool finished;
+    bool error;
+    bool canceled;
+};
+
+class JobModel : public QAbstractTableModel {
+    Backend * _backend;
+    std::vector<ProgressState> _progress;
+
+public:
+    enum Column {
+        NameColumn,
+        ProgressColumn,
+        COLUMN_COUNT,
+    };
+
+public:
+    JobModel(Backend *backend, QObject *parent = nullptr)
+        : QAbstractTableModel(parent)
+        , _backend(backend)
+        , _progress(
+            _backend->render_jobs().size(), ProgressState{0, 1, false, false, false}
+        )
+    {}
+
+    void set_progress(std::vector<ProgressState> const& progress) {
+        release_assert_equal(progress.size(), _progress.size());
+        _progress = progress;
+        emit dataChanged(
+            index(0, ProgressColumn),
+            index((int) (_progress.size() - 1), ProgressColumn));
+    }
+
+// impl QAbstractItemModel
+public:
+    int rowCount(const QModelIndex &parent) const override {
+        if (parent.isValid()) {
+            return 0;
+        }
+        return (int) _backend->render_jobs().size();
+    }
+
+    int columnCount(const QModelIndex &parent) const override {
+        if (parent.isValid()) {
+            return 0;
+        }
+        return COLUMN_COUNT;
+    }
+
+    QVariant headerData(
+        int section, Qt::Orientation orientation, int role
+    ) const override {
+        if (orientation != Qt::Horizontal) {
+            return {};
+        }
+        switch (role) {
+        case Qt::DisplayRole:
+            switch (section) {
+            case NameColumn: return tr("Name");
+            case ProgressColumn: return tr("Progress");
+            default: return {};
+            }
+        default:
+            return {};
+        }
+    }
+
+    QVariant data(const QModelIndex &index, int role) const override {
+        if (!index.isValid() || index.parent().isValid()) {
+            return {};
+        }
+        auto column = index.column();
+        if (column < 0 || column >= COLUMN_COUNT) {
+            return {};
+        }
+
+        auto const& jobs = _backend->render_jobs();
+        release_assert_equal(_progress.size(), jobs.size());
+
+        auto row = index.row();
+        if (row < 0 || row >= (int) jobs.size()) {
+            return {};
+        }
+
+        switch (column) {
+        case NameColumn:
+            switch (role) {
+            case Qt::DisplayRole:
+                return jobs[(size_t) row].name;
+            default:
+                return {};
+            }
+
+        case ProgressColumn:
+            switch (role) {
+            case Qt::DisplayRole: {
+                auto const& progress = _progress[(size_t) row];
+                return tr("%1%, %2/%3")
+                    .arg(progress.curr * 100 / progress.max)
+                    .arg(format_duration(progress.curr), format_duration(progress.max));
+            }
+            default:
+                return {};
+            }
+
+        default:
+            return {};
+        }
+    }
+};
+
+/// Create a consistent view of job progress.
+///
+/// Invariants:
+/// - If a job was canceled or ran into an error, and if finished == true, then
+///   (error || cancelled) == true.
+static std::vector<ProgressState> get_progress(Backend * backend) {
+    std::vector<ProgressState> progress;
+
+    auto const& jobs = backend->render_jobs();
+    progress.reserve(jobs.size());
+    for (auto const& job : jobs) {
+        // RenderJob reports error/canceled before finished. Make sure to check finished
+        // before checking error, so we don't see finished without error.
+        progress.push_back(ProgressState {
+            .curr = job.future.progressValue(),
+            .max = job.future.progressMaximum(),
+            .finished = job.future.isFinished(),
+            .error = job.future.isResultReadyAt(0),
+            .canceled = job.future.isCanceled(),
+        });
+    }
+
+    return progress;
+}
+
+RenderDialog::RenderDialog(Backend *backend, MainWindow *parent_win)
+    : QDialog(parent_win)
+    , _backend(backend)
+    , _win(parent_win)
+    , _model(new JobModel(_backend, this))
+{
+    setModal(true);
+    resize(700, 900);
+
+    auto c = this;
+    auto l = new QVBoxLayout(c);
+
+    {l__w(QProgressBar);
+        _progress = w;
+    }
+    {l__splitl(QSplitter);
+        l->setOrientation(Qt::Vertical);
+        {l__c_l(QWidget, QVBoxLayout);
+            l->setContentsMargins(0, 0, 0, 0);
+            {l__w(QLabel(tr("Progress:")));
+            }
+            {l__w(QTreeView);
+                _job_list = w;
+                w->setModel(_model);
+                // Hide the tree view on Linux, and unindent the rows on Windows. We're
+                // displaying a table model where rows never have children.
+                w->setRootIsDecorated(false);
+                w->resizeColumnToContents(JobModel::NameColumn);
+            }
+        }
+        {l__c_l(QWidget, QVBoxLayout);
+            l->setContentsMargins(0, -1, 0, 0);
+            {l__w(QLabel(tr("Errors:")));
+            }
+            {l__w(QPlainTextEdit);
+                _error_log = w;
+                w->setReadOnly(true);
+            }
+        }
+    }
+    {l__w(QPushButton(tr("Cancel")));
+        _cancel_close = w;
+    }
+
+    int total_progress = 0;
+
+    for (auto const& job : _backend->render_jobs()) {
+        auto watch = new QFutureWatcher<QString>(this);
+        connect(
+            watch, &QFutureWatcher<QString>::resultReadyAt,
+            this, [this, job=job](int idx) {
+                _error_log->appendPlainText(
+                    tr("Error rendering to \"%1\": %2").arg(
+                        job.path, job.future.resultAt(idx)
+                    )
+                );
+            });
+
+        // "To avoid a race condition, it is important to call this function *after*
+        // doing the connections."
+        watch->setFuture(job.future);
+        total_progress += job.future.progressMaximum();
+    }
+
+    _progress->setMaximum(total_progress);
+
+    // Connect GUI.
+    connect(
+        _cancel_close, &QPushButton::clicked,
+        this, &RenderDialog::cancel_or_close);
+
+    // Setup status timer.
+    _status_timer.setInterval(200);
+    connect(
+        &_status_timer, &QTimer::timeout,
+        this, &RenderDialog::update_status);
+
+    _status_timer.start();
+    update_status();
+}
+
+RenderDialog::~RenderDialog() = default;
+
+/// Called on a timer. Updates the progress table and checks if all render jobs are
+/// complete. If so, closes the dialog or switches the Cancel button to Close.
+///
+/// Does not check for errors and append them to the text area. That's handled by
+/// QFutureWatcher.
+void RenderDialog::update_status() {
+    auto job_progress = get_progress(_backend);
+
+    bool all_finished = true;
+    bool any_error = false;
+    bool any_canceled = false;
+    int curr_progress = 0;
+
+    for (auto const& job : job_progress) {
+        curr_progress += job.curr;
+        if (job.error) {
+            any_error = true;
+        }
+        if (job.canceled) {
+            any_canceled = true;
+        }
+        if (!job.finished) {
+            all_finished = false;
+        }
+    }
+
+    // Set the progress bar.
+    _progress->setValue(curr_progress);
+
+    // Update the job list.
+    _model->set_progress(job_progress);
+
+    // Only use values calculated from job_progress. Don't perform more queries to
+    // _backend, since you'll get an inconsistent view of rendering state.
+    if (all_finished) {
+        _done = true;
+        _status_timer.stop();
+
+        // If a render job isn't canceled (runs to completion or hits an error), set
+        // the progress bar to 100%. If it runs to completion, warn if there's a time
+        // mismatch.
+        if (!any_canceled) {
+            int max_progress = _progress->maximum();
+            if (!any_error && curr_progress != max_progress) {
+                _error_log->appendPlainText(
+                    tr("Warning: total rendered time of %1 seconds != calculated duration of %2 seconds!")
+                        .arg(curr_progress)
+                        .arg(max_progress)
+                );
+            }
+            _progress->setValue(max_progress);
+        }
+
+        if (_close_on_end) {
+            close();
+        } else {
+            _cancel_close->setText(tr("Close"));
+        }
+    }
+}
+
+void RenderDialog::cancel_or_close() {
+    if (_done) {
+        close();
+    } else {
+        _backend->cancel_render();
+    }
+}
+
+void RenderDialog::closeEvent(QCloseEvent * event) {
+    if (!_done) {
+        event->ignore();
+        _backend->cancel_render();
+        _close_on_end = true;
+    } else {
+        // Technically unnecessary.
+        event->accept();
+    }
+}

--- a/src/render_dialog.cpp
+++ b/src/render_dialog.cpp
@@ -257,9 +257,13 @@ void RenderDialog::update_status() {
     bool any_error = false;
     bool any_canceled = false;
     int curr_progress = 0;
+    int max_progress = 0;
 
     for (auto const& job : job_progress) {
         curr_progress += job.curr;
+        // Treat errored jobs as completed (max := curr).
+        max_progress += job.error ? job.curr : job.max;
+
         if (job.error) {
             any_error = true;
         }
@@ -272,6 +276,10 @@ void RenderDialog::update_status() {
     }
 
     // Set the progress bar.
+    if (max_progress == 0) {
+        curr_progress = max_progress = 1;
+    }
+    _progress->setMaximum(max_progress);
     _progress->setValue(curr_progress);
 
     // Update the job list.

--- a/src/render_dialog.h
+++ b/src/render_dialog.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QDialog>
+#include <QTimer>
+
+#include <memory>
+#include <vector>
+
+class MainWindow;
+class Backend;
+
+class QPlainTextEdit;
+class QProgressBar;
+class QPushButton;
+class QTreeView;
+class JobModel;
+
+class RenderDialog : public QDialog {
+private:
+    Backend * _backend;
+    MainWindow * _win;
+    JobModel * _model;
+
+    QProgressBar * _progress;
+    QTreeView * _job_list;
+    QPlainTextEdit * _error_log;
+    QPushButton * _cancel_close;
+
+    QTimer _status_timer;
+    bool _done = false;
+    bool _close_on_end = false;
+
+public:
+    RenderDialog(Backend * backend, MainWindow * parent_win);
+    ~RenderDialog();
+
+private:
+    void update_status();
+    void cancel_or_close();
+
+// impl QWidget
+protected:
+    void closeEvent(QCloseEvent * event) override;
+};


### PR DESCRIPTION
- [x] remove QAbstractTableModel from main
- [x] Add channel table or debug prints
- [x] Hide tree view column at left (Linux), or empty gap (Windows)
	- [`QTreeView::setTreePosition`](https://invent.kde.org/qt/qt/qtbase/-/blob/kde/5.15/src/widgets/itemviews/qtreeview.cpp#L981) vs. [`setRootIsDecorated`](https://invent.kde.org/qt/qt/qtbase/-/blob/kde/5.15/src/widgets/itemviews/qtreeview.cpp#L419)?
- [x] Check that I didn't copy vectors by mistake
- [x] use ~~callback~~ `Render()` return status rather than header to determine render time

> I usually set a callback function with `PlayerA::SetEventCallback()` and stop rendering at the `PLREVT_END` event.
> That makes it also resistant against incorrect header values for the song/loop length.

This results incorrect progress bars, and the warning message appearing, for .vgm files with incorrect headers. But this won't detect *all* incorrect headers, only those which are off by 1 second or more.

## Cancelled

- [ ] Add progress bar delegate? idk
- [ ] detect incorrect length/loop headers?

Fixes #7.