### PR TITLE
Prepare for adding render dialog

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -376,7 +376,6 @@ private:
         uint32_t curr_samp = 0;
         while (curr_samp < render_nsamp) {
             if (_status.isCanceled()) {
-                _status.reportResult(Backend::tr("Cancelled by user"));
                 return;
             }
 
@@ -414,7 +413,9 @@ public:
     void run() override {
         // Based off https://invent.kde.org/qt/qt/qtbase/-/blob/kde/5.15/src/concurrent/qtconcurrentrunbase.h#L95-121
         if (_status.isCanceled()) {
-            _status.reportResult(Backend::tr("Cancelled by user"));
+            // Ideally I'd report "Cancelled by user", but after QFuture::cancel() is
+            // called (and QFutureInterface::isCanceled() is set),
+            // QFutureInterface::reportResult() drops all values.
             _status.reportFinished();
             return;
         }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -16,6 +16,7 @@
 #include <player/s98player.hpp>
 #include <player/droplayer.hpp>
 #include <player/gymplayer.hpp>
+#include <emu/SoundDevs.h>
 #include <emu/SoundEmu.h>
 
 #include <stx/result.h>
@@ -57,6 +58,26 @@ struct DeleteDataLoader {
 };
 
 using BoxDataLoader = std::unique_ptr<DATA_LOADER, DeleteDataLoader>;
+
+static bool compare_chips(PLR_DEV_INFO const& a, PLR_DEV_INFO const& b) {
+    static constexpr auto key = [](uint8_t type) -> int {
+        // Order PSG after YM2612. Keep PSG before 32X, because base console chips
+        // should come before expansions.
+        static_assert(DEVID_SN76496 < DEVID_YM2612, "PSG already after YM2612");
+        if (type == DEVID_SN76496) {
+            return (int) (DEVID_YM2612 << 8) + 1;
+        }
+
+        // Add more overrides as necessary.
+        return (int) (type << 8);
+    };
+    return key(a.type) < key(b.type);
+}
+
+/// Sort chips in a more natural order for end users.
+static void sort_chips(std::vector<PLR_DEV_INFO> & devices) {
+    std::stable_sort(devices.begin(), devices.end(), compare_chips);
+}
 
 struct Metadata {
     uint32_t player_type;
@@ -105,6 +126,7 @@ public:
 
         PlayerBase * engine = player->GetPlayer();
         engine->GetSongDeviceInfo(devices);
+        sort_chips(devices);
 
         std::vector<ChipMetadata> chips;
         std::vector<FlatChannelMetadata> flat_channels = {

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -359,6 +359,11 @@ public:
         });
         // Progress range is [0..time in seconds].
         out->_status.setProgressRange(0, (int) (render_nsamp / opt.sample_rate));
+
+        // The initial progress value is already 0, but we need to call
+        // setProgressValue(0) so reportResult() doesn't increment the progress value.
+        out->_status.setProgressValue(0);
+
         return Ok(std::move(out));
     }
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -24,7 +24,11 @@ struct ChipMetadata {
     uint8_t chip_idx;
 };
 
-using RenderJobHandle = QFuture<QString>;
+struct RenderJobHandle {
+    QString name;
+    QString path;
+    QFuture<QString> future;
+};
 
 /// Uniquely identifies a channel in a .vgm file.
 /// The metadata used to mute a particular channel by setting

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -271,7 +271,7 @@ public:
 
 // impl QWidget
     QSize sizeHint() const {
-        return QSize(128, 128);
+        return QSize(144, 144);
     }
 };
 
@@ -379,6 +379,20 @@ public:
     }
 };
 
+class SmallButton : public QPushButton {
+public:
+    // SmallButton()
+    using QPushButton::QPushButton;
+
+// impl QWidget
+public:
+    QSize sizeHint() const {
+        auto out = QPushButton::sizeHint();
+        out.setWidth(0);
+        return out;
+    }
+};
+
 static QString errors_to_html(QString const& prefix, std::vector<QString> const& errors) {
     QTextDocument document;
     auto cursor = QTextCursor(&document);
@@ -483,10 +497,10 @@ public:
                     w->setModel(&_chips_model);
                 }
                 {l__l(QHBoxLayout);
-                    {l__w(QPushButton(tr("&Up")));
+                    {l__w(SmallButton(tr("&Up")));
                         _move_up = w;
                     }
-                    {l__w(QPushButton(tr("&Down")));
+                    {l__w(SmallButton(tr("&Down")));
                         _move_down = w;
                     }
                 }


### PR DESCRIPTION
.vgm bugfixes:

- Fix the reported duration of unlooped songs
- Fix silent gaps when songs end

GUI features:

- Add chip reordering buttons to main window
- Highlight the first chip, which gets moved by the up/down buttons
- Sort YM2612 before PSG

GUI bugfixes:

- Don't increment timestamp when reporting render errors