### PR TITLE
Fix render progress bar slowing down when only master audio is left 

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -132,9 +132,9 @@ public:
         std::vector<FlatChannelMetadata> flat_channels = {
             FlatChannelMetadata {
                 .name = "Master Audio",
-                .chip_idx = (uint8_t) -1,
-                .subchip_idx = (uint8_t) -1,
-                .chan_idx = (uint8_t) -1,
+                .maybe_chip_idx = (uint8_t) -1,
+                .subchip_idx = 0,
+                .chan_idx = 0,
                 .enabled = true,
             }
         };
@@ -160,7 +160,7 @@ public:
             ) {
                 flat_channels.push_back(FlatChannelMetadata {
                     .name = move(channel.name),
-                    .chip_idx = chip_idx,
+                    .maybe_chip_idx = chip_idx,
                     .subchip_idx = channel.subchip_idx,
                     .chan_idx = channel.chan_idx,
                     .enabled = true,
@@ -582,11 +582,13 @@ void Backend::sort_channels() {
     std::stable_sort(
         channels.begin(), channels.end(),
         [&chip_idx_to_order](FlatChannelMetadata const& a, FlatChannelMetadata const& b) {
-            if (a.chip_idx == NO_CHIP || b.chip_idx == NO_CHIP) {
-                return (a.chip_idx != NO_CHIP) < (b.chip_idx != NO_CHIP);
+            if (a.maybe_chip_idx == NO_CHIP || b.maybe_chip_idx == NO_CHIP) {
+                return (a.maybe_chip_idx != NO_CHIP) < (b.maybe_chip_idx != NO_CHIP);
             }
             // Both a.chip_idx and b.chip_idx are valid indices.
-            return chip_idx_to_order[a.chip_idx] < chip_idx_to_order[b.chip_idx];
+            return
+                chip_idx_to_order[a.maybe_chip_idx]
+                < chip_idx_to_order[b.maybe_chip_idx];
         });
 }
 
@@ -652,9 +654,9 @@ std::vector<QString> Backend::start_render(QString const& path) {
         QString channel_path;
 
         // For per-channel jobs, solo the channel.
-        if (channel.chip_idx != (uint8_t) -1) {
+        if (channel.maybe_chip_idx != (uint8_t) -1) {
             solo = SoloSettings {
-                .chip_idx = channel.chip_idx,
+                .chip_idx = channel.maybe_chip_idx,
                 .subchip_idx = channel.subchip_idx,
                 .chan_idx = channel.chan_idx,
             };

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -87,7 +87,7 @@ struct Metadata {
 
     /// Master audio renders more slowly than individual channels, so make it take up
     /// more space in the overall progress bar.
-    int master_audio_time_multiplier;
+    float master_audio_time_multiplier;
 
 // impl
 public:
@@ -184,8 +184,8 @@ public:
         deal, since Master System .vgm files render quickly, and have ≤ channels than
         most people have CPU cores.
         */
-        int master_audio_time_multiplier =
-            std::max(1, qRound((float) flat_channels.size() / 2.f));
+        float master_audio_time_multiplier =
+            std::max(1.f, (float) flat_channels.size() / 2.f);
 
         return Ok(std::make_unique<Metadata>(Metadata {
             .player_type = engine->GetPlayerType(),
@@ -246,7 +246,7 @@ struct RenderJobState {
 
     QString _out_path;
 
-    int _time_multiplier;
+    float _time_multiplier;
 
     /// Implicitly shared, read-only.
     QByteArray _file_data;
@@ -367,7 +367,7 @@ public:
             engine->Tick2Sample(engine->GetTotalPlayTicks(player->GetLoopCount()))
             + extra_nsamp;
 
-        int time_multiplier = 1;
+        float time_multiplier = 1.f;
 
         // Mute all but one channel.
         if (opt.solo) {

--- a/src/backend.h
+++ b/src/backend.h
@@ -27,7 +27,7 @@ struct ChipMetadata {
 struct RenderJobHandle {
     QString name;
     QString path;
-    int time_multiplier;
+    float time_multiplier;
     QFuture<QString> future;
 };
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -27,6 +27,7 @@ struct ChipMetadata {
 struct RenderJobHandle {
     QString name;
     QString path;
+    int time_multiplier;
     QFuture<QString> future;
 };
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -40,7 +40,7 @@ struct FlatChannelMetadata {
 
     /// Depends on the .vgm file. If -1, all chips/channels are rendered
     /// (master audio).
-    uint8_t chip_idx;
+    uint8_t maybe_chip_idx;
 
     /// Usually 0. YM2608's PSG channels have it set to 1.
     uint8_t subchip_idx;

--- a/src/render_dialog.cpp
+++ b/src/render_dialog.cpp
@@ -26,7 +26,7 @@ static QString format_duration(int seconds) {
 struct ProgressState {
     int curr;
     int max;
-    int time_multiplier;
+    float time_multiplier;
     bool finished;
     bool error;
     bool canceled;
@@ -263,9 +263,11 @@ void RenderDialog::update_status() {
     int max_progress = 0;
 
     for (auto const& job : job_progress) {
-        curr_progress += job.time_multiplier * job.curr;
+        curr_progress += (int) ((double) job.time_multiplier * (double) job.curr);
+
         // Treat errored jobs as completed (max := curr).
-        max_progress += job.time_multiplier * (job.error ? job.curr : job.max);
+        int job_max = job.error ? job.curr : job.max;
+        max_progress += (int) ((double) job.time_multiplier * (double) job_max);
 
         if (job.error) {
             any_error = true;

--- a/src/render_dialog.cpp
+++ b/src/render_dialog.cpp
@@ -169,6 +169,7 @@ RenderDialog::RenderDialog(Backend *backend, MainWindow *parent_win)
     , _model(new JobModel(_backend, this))
 {
     setModal(true);
+    setWindowTitle(tr("Rendering..."));
     resize(700, 900);
 
     auto c = this;
@@ -309,6 +310,7 @@ void RenderDialog::update_status() {
         if (_close_on_end) {
             close();
         } else {
+            setWindowTitle(tr("Render Complete"));
             _cancel_close->setText(tr("Close"));
         }
     }


### PR DESCRIPTION
The master audio channel generally takes much longer to render than each soloed channel. As a result, the progress bar often reaches around 90% when all the individual channels finish rendering, and then slows down to a crawl as the master audio finishes rendering. In my testing, I mistakenly thought the render had completed, and cancelled the render before it finished.

This multiplies the space taken up by master audio in the progress bar by (total channels including muted) / 2, which is approximately how much slower it is to render master audio compared to individual channels. As a result, the progress bar moves much more smoothly.

There's still the possibility of mistakenly thinking the render is complete when it hits 100% but the individual jobs are still a split-second away from completion. Perhaps there should be a more visible indicator (separate abort and done buttons?).