### PR TITLE
Prepend master audio name when rendering channels

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -688,9 +688,11 @@ std::vector<QString> Backend::start_render(QString const& path) {
                 .subchip_idx = channel.subchip_idx,
                 .chan_idx = channel.chan_idx,
             };
-            channel_path = QFileInfo(path)
-                .dir()
-                .absoluteFilePath(QStringLiteral("%1.wav").arg(channel_name));
+            auto info = QFileInfo(path);
+            channel_path = info.dir()
+                .absoluteFilePath(QStringLiteral("%1 - %2.wav").arg(
+                    info.baseName(), channel_name
+                ));
         } else {
             channel_path = path;
         }


### PR DESCRIPTION
This avoids rendering one file from overwriting channels from another file.

It also prevents "03 Song Name.wav" from being sorted between "03 - Channel 3.wav" and "04 - Channel 4.wav", since the channels are instead called "03 Song Name - 03 - Channel 3.wav" instead.

- [ ] ~~Get more feedback~~
- [x] Review code
- [x] Test on Windows
- [ ] ~~Shorten name~~ Deferred.

```
01 Title Screen - 18 - Channel 18.wav
01 Title Screen - 19 - Bass Drum.wav
```

File names are too long. ~~Replace with colon?~~ NTFS-incompatible. Remove second hyphen? In UI or export too?

![Discord_gJyncWFCQn](https://user-images.githubusercontent.com/913957/147782617-f270103f-7ea6-4ba7-bb0d-72cd9d85d097.png)

Looks weird, but at least it's consistent with video game OSTs (no hyphen).

https://www.zophar.net/music/nintendo-snes-spc/chrono-trigger shows "101.  Presentiment", but the download has no dot.

See issue #16.