### PR TITLE
Improve names and order of YM2608/YM2610 channels

### DIFF
--- a/src/ARCHITECTURE.md
+++ b/src/ARCHITECTURE.md
@@ -1,0 +1,15 @@
+## Architecture
+
+There is one `Backend` created over the entire lifetime of the app, which holds the channel list of the loaded .vgm file, and renders when needed. `MainWindow` can tell `Backend` to load a different VGM file. `StateTransaction` is used to setup app state on startup, and manages reloading state in response to user interactions (switching files, reordering chips, currently not toggling channels). I may eventually move `StateTransaction` to backend.h and remove its `MainWindowImpl *` field, then have `MainWindow` subscribe to a new `Backend::stateChanged(StateTransaction &)` signal instead.
+
+## Channel order
+
+When opening a new VGM file, `Metadata::make()` loads the list of chips and channels. To enumerate the chips in a VGM file, it calls `PlayerBase::GetSongDeviceInfo()` which returns an ordered list of chip IDs. We mostly keep libvgm's chip order intact, but to improve Sega Genesis songs, we reorder SN76496 after YM2612. To map each chip to a list of channels, `Metadata::make()` calls a function located in `vgm.cpp`. This file mostly keeps libvgm's channel order intact, but in the case of YM2608, it reorders SSG before rhythm and ADPCM.
+
+`Metadata` stores a chip list and a flat channel list. The user can reorder chips but not channels. When the user reorders chips, we reorder the flat channel list to match.
+
+## Rendering
+
+Rendering is managed in `Backend`. Render jobs (either a single soloed channel, or master audio) are sent to a `QThreadPool`, which spawns 1 thread per CPU core and distributes jobs among threads. For most sound chips, the master audio job takes much longer than the other jobs. If this was not the case, some renders could complete more quickly by spawning more threads than CPU cores (eg. on a 4-core CPU, rendering 5 channels simultaneously is faster than only rendering 4 channels initially, then starting the 5th channel once one channel finishes).
+
+While a render is active, the modal `RenderDialog` shows the rendering progress, and blocks the user from interacting with `MainWindow` and editing `Backend` until the render is finished.

--- a/src/vgm.cpp
+++ b/src/vgm.cpp
@@ -80,6 +80,7 @@ std::vector<ChannelMetadata> get_chip_metadata(
         break;
     case DEVID_YM2608:
     case DEVID_YM2610:
+    {
         nchannel = 16;	// 6 FM + 6 ADPCM + 1 DeltaT + 3 AY8910
         ngroup = 3;
 
@@ -87,12 +88,19 @@ std::vector<ChannelMetadata> get_chip_metadata(
         group_names[0] = "FM Chn";
 
         channels_per_group[1] = 7;
-        group_names[1] = "PCM Chn";
-        channel_names[channels_per_group[0] + 6] = "Delta-T";
+        auto pcm_begin = channels_per_group[0];
+        channel_names[pcm_begin + 0] = "Bass Drum";
+        channel_names[pcm_begin + 1] = "Snare Drum";
+        channel_names[pcm_begin + 2] = "Top Cymbal";
+        channel_names[pcm_begin + 3] = "Hi-Hat";
+        channel_names[pcm_begin + 4] = "Tom Tom";
+        channel_names[pcm_begin + 5] = "Rim Shot";
+        channel_names[pcm_begin + 6] = "Delta-T";
 
         channels_per_group[2] = 3;
         group_names[2] = "SSG Chn";
         break;
+    }
     case DEVID_YMF262:
         nchannel = 23;	// 18 + 5
         channel_names[18] = "Bass Drum";

--- a/src/vgm.cpp
+++ b/src/vgm.cpp
@@ -89,13 +89,19 @@ std::vector<ChannelMetadata> get_chip_metadata(
 
         channels_per_group[1] = 7;
         auto pcm_begin = channels_per_group[0];
-        channel_names[pcm_begin + 0] = "Bass Drum";
-        channel_names[pcm_begin + 1] = "Snare Drum";
-        channel_names[pcm_begin + 2] = "Top Cymbal";
-        channel_names[pcm_begin + 3] = "Hi-Hat";
-        channel_names[pcm_begin + 4] = "Tom Tom";
-        channel_names[pcm_begin + 5] = "Rim Shot";
-        channel_names[pcm_begin + 6] = "ADPCM";
+
+        if (chip_type == DEVID_YM2608) {
+            channel_names[pcm_begin + 0] = "Bass Drum";
+            channel_names[pcm_begin + 1] = "Snare Drum";
+            channel_names[pcm_begin + 2] = "Top Cymbal";
+            channel_names[pcm_begin + 3] = "Hi-Hat";
+            channel_names[pcm_begin + 4] = "Tom Tom";
+            channel_names[pcm_begin + 5] = "Rim Shot";
+            channel_names[pcm_begin + 6] = "ADPCM";
+        } else {
+            group_names[1] = "ADPCM-A";
+            channel_names[pcm_begin + 6] = "ADPCM-B";
+        }
 
         channels_per_group[2] = 3;
         group_names[2] = "SSG Chn";

--- a/src/vgm.cpp
+++ b/src/vgm.cpp
@@ -52,7 +52,7 @@ std::vector<ChannelMetadata> get_chip_metadata(
         if (chip_type == DEVID_Y8950)
         {
             nchannel = 15;
-            channel_names[14] = "Delta-T";
+            channel_names[14] = "ADPCM";
         }
         break;
     case DEVID_YM2612:
@@ -95,7 +95,7 @@ std::vector<ChannelMetadata> get_chip_metadata(
         channel_names[pcm_begin + 3] = "Hi-Hat";
         channel_names[pcm_begin + 4] = "Tom Tom";
         channel_names[pcm_begin + 5] = "Rim Shot";
-        channel_names[pcm_begin + 6] = "Delta-T";
+        channel_names[pcm_begin + 6] = "ADPCM";
 
         channels_per_group[2] = 3;
         group_names[2] = "SSG Chn";


### PR DESCRIPTION
- Add names to YM2608 rhythm channels
- Rename YM2610 sample channels to ADPCM-A/B
- Reorder SSG before rhythm/ADPCM to group melodic channels together and match BambooTracker

I reordered SSG before rhythm/ADPCM by processing the groups in a different order, not by applying an arbitrary permutation to the output channels. IDK if this was a good idea. This is less flexible (and I'll revert my changes if I add arbitrary permutations), but more declarative rather than being based on magic numbers (channel indexes). Ideally I'd use an enum (class?) per chip whose order matches libvgm, and I feed an array of these enum values into a permuting function when needed.

Steps:

- [x] Review code
- [x] Test in ASAN?
- [x] Test that SMS/Genesis/OPL/32X have unaltered channel names
	- [x] Genesis/32X FM and PSG play in the wrong order!
		- Already broken in master! Fixed in #34.

Fixes #28.