### PR TITLE
Rewrite channel muting, fix PSG and YM2612 being swapped

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -602,9 +602,11 @@ std::vector<ChipMetadata> & Backend::chips_mut() {
 
 void Backend::sort_channels() {
     auto const& chips = _metadata->chips;
-    std::unordered_map<ChipId, uint8_t> chip_id_to_order(chips.size());
+    std::unordered_map<ChipId, uint16_t> chip_id_to_order(chips.size() + 1);
+    chip_id_to_order.insert({NO_CHIP, 0});
+
     for (auto const& [i, chip] : enumerate<uint8_t>(chips)) {
-        chip_id_to_order.insert({chip.chip_id, i});
+        chip_id_to_order.insert({chip.chip_id, i + 1});
     }
 
     auto & channels = _metadata->flat_channels;
@@ -612,10 +614,6 @@ void Backend::sort_channels() {
     std::stable_sort(
         channels.begin(), channels.end(),
         [&chip_id_to_order](FlatChannelMetadata const& a, FlatChannelMetadata const& b) {
-            if (a.maybe_chip_id == NO_CHIP || b.maybe_chip_id == NO_CHIP) {
-                return (a.maybe_chip_id != NO_CHIP) < (b.maybe_chip_id != NO_CHIP);
-            }
-            // Both a.chip_idx and b.chip_idx are valid indices.
             return
                 chip_id_to_order.at(a.maybe_chip_id)
                 < chip_id_to_order.at(b.maybe_chip_id);

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -34,6 +34,7 @@
 #include <cstdint>
 #include <iostream>
 #include <optional>
+#include <unordered_map>
 
 //#define BACKEND_DEBUG
 
@@ -136,7 +137,7 @@ public:
         std::vector<FlatChannelMetadata> flat_channels = {
             FlatChannelMetadata {
                 .name = "Master Audio",
-                .maybe_chip_idx = (uint8_t) -1,
+                .maybe_chip_id = NO_CHIP,
                 .subchip_idx = 0,
                 .chan_idx = 0,
                 .enabled = true,
@@ -146,16 +147,18 @@ public:
         chips.reserve(devices.size());
         bool show_chip_name = devices.size() > 1;
 
-        for (auto const& [chip_idx, device] : enumerate<uint8_t>(devices)) {
+        for (auto const& device : devices) {
             constexpr UINT8 OPTS = 0x01;  // enable long names
             const char* chipName = SndEmu_GetDevName(device.type, OPTS, device.devCfg);
 #ifdef BACKEND_DEBUG
             std::cerr << chipName << "\n";
 #endif
 
+            ChipId chip_id =
+                PLR_DEV_ID((uint32_t) device.type, (uint32_t) device.instance);
             chips.push_back(ChipMetadata {
                 .name = chipName,
-                .chip_idx = chip_idx,
+                .chip_id = chip_id,
             });
 
             for (
@@ -164,7 +167,7 @@ public:
             ) {
                 flat_channels.push_back(FlatChannelMetadata {
                     .name = move(channel.name),
-                    .maybe_chip_idx = chip_idx,
+                    .maybe_chip_id = chip_id,
                     .subchip_idx = channel.subchip_idx,
                     .chan_idx = channel.chan_idx,
                     .enabled = true,
@@ -211,8 +214,8 @@ QString FlatChannelMetadata::numbered_name(size_t row) const {
 }
 
 struct SoloSettings {
-    /// Depends on the .vgm file.
-    uint8_t chip_idx;
+    /// Encodes the chip type and which index it is.
+    ChipId chip_id;
 
     /// Usually 0. YM2608's PSG channels have it set to 1.
     uint8_t subchip_idx;
@@ -373,11 +376,10 @@ public:
         if (opt.solo) {
             SoloSettings const& solo = *opt.solo;
 
-            auto nchip = metadata.chips.size();
-            for (size_t chip_idx = 0; chip_idx < nchip; chip_idx++) {
+            for (ChipMetadata const& chip : metadata.chips) {
                 PLR_MUTE_OPTS mute{};
 
-                if (chip_idx != solo.chip_idx) {
+                if (chip.chip_id != solo.chip_id) {
                     mute.disable = 0xff;
                     // Probably unnecessary, but do it anyway.
                     mute.chnMute[0] = mute.chnMute[1] = ~0u;
@@ -392,7 +394,7 @@ public:
                         mute.chnMute[subchip_idx] = (~0u) ^ (1 << solo.chan_idx);
                     }
                 }
-                status = engine->SetDeviceMuting((uint32_t) chip_idx, mute);
+                status = engine->SetDeviceMuting(chip.chip_id, mute);
                 assert(status == 0);
             }
         } else {
@@ -600,23 +602,23 @@ std::vector<ChipMetadata> & Backend::chips_mut() {
 
 void Backend::sort_channels() {
     auto const& chips = _metadata->chips;
-    std::vector<uint8_t> chip_idx_to_order(chips.size());
+    std::unordered_map<ChipId, uint8_t> chip_id_to_order(chips.size());
     for (auto const& [i, chip] : enumerate<uint8_t>(chips)) {
-        chip_idx_to_order[chip.chip_idx] = i;
+        chip_id_to_order.insert({chip.chip_id, i});
     }
 
     auto & channels = _metadata->flat_channels;
 
     std::stable_sort(
         channels.begin(), channels.end(),
-        [&chip_idx_to_order](FlatChannelMetadata const& a, FlatChannelMetadata const& b) {
-            if (a.maybe_chip_idx == NO_CHIP || b.maybe_chip_idx == NO_CHIP) {
-                return (a.maybe_chip_idx != NO_CHIP) < (b.maybe_chip_idx != NO_CHIP);
+        [&chip_id_to_order](FlatChannelMetadata const& a, FlatChannelMetadata const& b) {
+            if (a.maybe_chip_id == NO_CHIP || b.maybe_chip_id == NO_CHIP) {
+                return (a.maybe_chip_id != NO_CHIP) < (b.maybe_chip_id != NO_CHIP);
             }
             // Both a.chip_idx and b.chip_idx are valid indices.
             return
-                chip_idx_to_order[a.maybe_chip_idx]
-                < chip_idx_to_order[b.maybe_chip_idx];
+                chip_id_to_order.at(a.maybe_chip_id)
+                < chip_id_to_order.at(b.maybe_chip_id);
         });
 }
 
@@ -682,9 +684,9 @@ std::vector<QString> Backend::start_render(QString const& path) {
         QString channel_path;
 
         // For per-channel jobs, solo the channel.
-        if (channel.maybe_chip_idx != (uint8_t) -1) {
+        if (channel.maybe_chip_id != NO_CHIP) {
             solo = SoloSettings {
-                .chip_idx = channel.maybe_chip_idx,
+                .chip_id = channel.maybe_chip_id,
                 .subchip_idx = channel.subchip_idx,
                 .chan_idx = channel.chan_idx,
             };

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -21,6 +21,7 @@
 
 #include <stx/result.h>
 
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -151,7 +152,7 @@ public:
             constexpr UINT8 OPTS = 0x01;  // enable long names
             const char* chipName = SndEmu_GetDevName(device.type, OPTS, device.devCfg);
 #ifdef BACKEND_DEBUG
-            std::cerr << chipName << "\n";
+            qDebug() << chipName;
 #endif
 
             ChipId chip_id =
@@ -581,11 +582,12 @@ QString Backend::load_path(QString const& path) {
 
 #ifdef BACKEND_DEBUG
     for (auto const& metadata : _metadata->flat_channels) {
-        std::cerr
-            << (int) metadata.chip_idx << " "
-            << (int) metadata.subchip_idx << " "
-            << (int) metadata.chan_idx << " "
-            << metadata.name << "\n";
+        qDebug()
+            << QStringLiteral("0x%1")
+                .arg(metadata.maybe_chip_id, 8, 16, QLatin1Char('0'))
+            << metadata.subchip_idx
+            << metadata.chan_idx
+            << QString::fromStdString(metadata.name);
     }
 #endif
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -19,9 +19,12 @@ struct Metadata;
 // But I'm not sure how to best integrate it into C++. And QAbstractItemModel isn't
 // "best integrated", but worst. Maybe an ECS would do better?
 
+/// Obtained by calling PLR_DEV_ID(PLR_DEV_INFO::type, PLR_DEV_INFO::instance).
+using ChipId = uint32_t;
+
 struct ChipMetadata {
     std::string name;
-    uint8_t chip_idx;
+    ChipId chip_id;
 };
 
 struct RenderJobHandle {
@@ -34,14 +37,14 @@ struct RenderJobHandle {
 /// Uniquely identifies a channel in a .vgm file.
 /// The metadata used to mute a particular channel by setting
 /// PLR_MUTE_OPTS::chnMute[subchip_idx] |= 1u << chan_idx
-/// and calling SetDeviceMuting(chip_idx, muteOpts).
+/// and calling SetDeviceMuting(chip_id, muteOpts).
 struct FlatChannelMetadata {
     /// Includes chip and channel name.
     std::string name;
 
     /// Depends on the .vgm file. If -1, all chips/channels are rendered
     /// (master audio).
-    uint8_t maybe_chip_idx;
+    ChipId maybe_chip_id;
 
     /// Usually 0. YM2608's PSG channels have it set to 1.
     uint8_t subchip_idx;
@@ -56,7 +59,7 @@ struct FlatChannelMetadata {
     QString numbered_name(size_t row) const;
 };
 
-constexpr uint8_t NO_CHIP = (uint8_t) -1;
+constexpr ChipId NO_CHIP = (ChipId) -1;
 
 class Backend {
     Q_DECLARE_TR_FUNCTIONS(Backend)


### PR DESCRIPTION
This rewrites chip/channel muting to pass `PLR_DEV_ID()` values into `PlayerBase::SetDeviceMuting()`. Previously we passed in chip indexes, which were technically incorrect since `SetDeviceMuting` is intended to be called with `PLR_DEV_INFO::id` rather than chip indexes. Obtaining a valid `PLR_DEV_INFO::id` requires you to call `Start()` first, and if a core fails to load (eg. by specifying an invalid core name override), subsequent cores have lower ids than otherwise. This causes `PLR_DEV_INFO::id` to change even without switching VGM files (if you switch between valid and invalid core overrides), and can cause qvgmsplit to mute the wrong device's channels. IMO I'd make `PLR_DEV_INFO::id` correspond to `GetSongDeviceInfo` indexes, not successfully loaded cores. But with libvgm in its current state, it's more reliable to use `PLR_DEV_ID()` instead.

This also fixes PSG and YM2612 channels being swapped during rendering. The bug was introduced in 027736ec402a4d245bb704844097da4dbec9f261, and went unnoticed for 3 weeks. Ideally I'd add unit tests that the channel layout is correct, and/or a GUI playback preview feature that doesn't require rendering to WAV.

- [ ] Review code
- Test on consoles:
	- [x] SMS
	- [x] OPL2/OPL3
	- [x] OPL3 DRO (device instance 2 even though there's only 1 OPL3)
		- works, but surprisingly each channel is nearly as slow as master audio, whereas ~~with OPL3 VGM each channel is much faster~~ dro2vgm is as slow as dro
	- [x] YM2608
	- [x] YM2610
	- [x] YM2612/32X
- [x] Is passing `PLR_DEV_INFO:instance` into `PLR_DEV_ID` correct even in DRO/GYM where instance == id, rather than always being 0 for the first chip of a kind?
- [x] Test in ASAN?

Supersedes #34.