### PR TITLE
Add settings system to configure sampling rate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ set(PROJECT_SOURCES
     src/main.cpp
     src/mainwindow.cpp
     src/mainwindow.h
+    src/options_dialog.cpp
+    src/options_dialog.h
     src/render_dialog.cpp
     src/render_dialog.h
     src/settings.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ set(PROJECT_SOURCES
     src/mainwindow.h
     src/render_dialog.cpp
     src/render_dialog.h
+    src/settings.cpp
+    src/settings.h
     src/vgm.cpp
     src/vgm.h
     src/wave_writer.cpp

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -745,6 +745,14 @@ void Backend::sort_channels() {
         });
 }
 
+bool Backend::is_file_loaded() const {
+    return _metadata->is_file_loaded();
+}
+
+uint32_t Backend::sample_rate() const {
+    return _metadata->sample_rate;
+}
+
 std::vector<FlatChannelMetadata> const& Backend::channels() const {
     return _metadata->flat_channels;
 }

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -539,7 +539,8 @@ public:
 };
 
 Backend::Backend()
-    : _metadata(std::make_unique<Metadata>(Metadata {}))
+    : _settings(Settings::make())
+    , _metadata(std::make_unique<Metadata>(Metadata {}))
 {
 }
 

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -710,11 +710,8 @@ QString Backend::load_path(QString const& path) {
     return {};
 }
 
-void Backend::reload_settings() {
-    QString err = _metadata->load_settings(_file_data, _settings.app_settings());
-
-    // Assert on debug builds.
-    assert(err.isEmpty());
+QString Backend::reload_settings() {
+    return _metadata->load_settings(_file_data, _settings.app_settings());
 }
 
 std::vector<ChipMetadata> const& Backend::chips() const {

--- a/src/backend.h
+++ b/src/backend.h
@@ -94,6 +94,9 @@ public:
     std::vector<ChipMetadata> & chips_mut();
     void sort_channels();
 
+    bool is_file_loaded() const;
+    uint32_t sample_rate() const;
+
     /// Includes an extra entry for "Master Audio".
     std::vector<FlatChannelMetadata> const& channels() const;
     std::vector<FlatChannelMetadata> & channels_mut();

--- a/src/backend.h
+++ b/src/backend.h
@@ -80,6 +80,14 @@ public:
     Backend();
     ~Backend();
 
+    // TODO only expose through StateTransaction?
+    Settings const& settings() const {
+        return _settings;
+    }
+    Settings & settings_mut() {
+        return _settings;
+    }
+
     /// If non-empty, holds error message.
     [[nodiscard]] QString load_path(QString const& path);
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -63,6 +63,7 @@ struct FlatChannelMetadata {
 
 constexpr ChipId NO_CHIP = (ChipId) -1;
 
+class StateTransaction;
 class Backend {
     Q_DECLARE_TR_FUNCTIONS(Backend)
 
@@ -80,16 +81,14 @@ public:
     Backend();
     ~Backend();
 
-    // TODO only expose through StateTransaction?
     Settings const& settings() const {
         return _settings;
     }
-    Settings & settings_mut() {
-        return _settings;
-    }
+    Settings & settings_mut(StateTransaction & tx);
 
     /// If non-empty, holds error message.
     [[nodiscard]] QString load_path(QString const& path);
+    void reload_settings();
 
     std::vector<ChipMetadata> const& chips() const;
     std::vector<ChipMetadata> & chips_mut();

--- a/src/backend.h
+++ b/src/backend.h
@@ -88,7 +88,8 @@ public:
 
     /// If non-empty, holds error message.
     [[nodiscard]] QString load_path(QString const& path);
-    void reload_settings();
+    /// If non-empty, holds error message.
+    [[nodiscard]] QString reload_settings();
 
     std::vector<ChipMetadata> const& chips() const;
     std::vector<ChipMetadata> & chips_mut();

--- a/src/backend.h
+++ b/src/backend.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "settings.h"
+
 #include <player/playera.hpp>
 
 #include <QCoreApplication>
@@ -67,6 +69,7 @@ class Backend {
     /// Whether the GUI is being updated in response to events.
     bool _during_update = false;
 
+    Settings _settings;
     QByteArray _file_data;
     std::unique_ptr<Metadata> _metadata;
     QThreadPool _render_thread_pool;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -644,6 +644,12 @@ public:
 
         // Disable render button when no file is open.
         _render->setDisabled(_backend.channels().empty());
+
+        reload_settings();
+    }
+
+    void reload_settings() {
+        // TODO update status bar
     }
 
     void move_up() {
@@ -785,6 +791,14 @@ StateTransaction::~StateTransaction() noexcept(false) {
         _win->update_file_status();
     }
 
+    // Metadata (sampling rate, etc.)
+    if (e & E::FileReplaced) {
+        // we already switched files, don't reload settings
+    } else if (e & E::SettingsChanged) {
+        _win->_backend.reload_settings();
+        _win->reload_settings();
+    }
+
     // Chips list
     if (e & E::FileReplaced) {
         _win->_chips_model.end_reset_model();
@@ -835,4 +849,8 @@ void StateTransaction::chips_changed() {
         _win->_channels_model.begin_reset_model();
         _queued_updates |= E::ChipsEdited;
     }
+}
+
+void StateTransaction::settings_changed() {
+    _queued_updates |= E::SettingsChanged;
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -612,6 +612,11 @@ public:
         }
     }
 
+    void show_error(QString const& err) {
+        _error_dialog.close();
+        _error_dialog.showMessage(err);
+    }
+
     void load_path(QString file_path) {
         auto tx = edit_unwrap();
 
@@ -623,10 +628,7 @@ public:
         auto err = _backend.load_path(file_path);
 
         if (!err.isEmpty()) {
-            _error_dialog.close();
-            _error_dialog.showMessage(
-                tr("Error loading file \"%1\":<br>%2").arg(file_path, err)
-            );
+            show_error(tr("Error loading file \"%1\":<br>%2").arg(file_path, err));
         } else {
             _file_path = file_path;
         }
@@ -711,9 +713,7 @@ public:
             // created, when it's actually scheduled; these errors show up in
             // Backend::render_jobs()[].results().
 
-            _error_dialog.showMessage(
-                errors_to_html(tr("Errors starting render:"), err)
-            );
+            show_error(errors_to_html(tr("Errors starting render:"), err));
 
             // _backend.is_rendering() *should* be false, but just in case it's true,
             // start the timer and call update_render_status() anyway (instead of
@@ -806,7 +806,13 @@ StateTransaction::~StateTransaction() noexcept(false) {
     if (e & E::FileReplaced) {
         // we already switched files, don't reload settings
     } else if (e & E::SettingsChanged) {
-        _win->_backend.reload_settings();
+        QString err = _win->_backend.reload_settings();
+        if (!err.isEmpty()) {
+            _win->show_error(
+                MainWindow::tr("Error applying settings:<br>%1").arg(err)
+            );
+        }
+
         _win->reload_settings();
     }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,6 @@
 #include "mainwindow.h"
 #include "render_dialog.h"
+#include "options_dialog.h"
 #include "gui_app.h"
 #include "lib/defer.h"
 #include "lib/layout_macros.h"
@@ -493,6 +494,8 @@ public:
     QAction * _render;
     QAction * _exit;
 
+    QAction * _options;
+
     QString _file_title;
     QString _file_path;
 
@@ -531,6 +534,11 @@ public:
                     _exit = a;
                 }
             }
+            {m__m(tr("&Tools"));
+                {m__action(tr("&Options"));
+                    _options = a;
+                }
+            }
         }
 
         {main__tb(QToolBar);
@@ -538,6 +546,8 @@ public:
 
             tb->addAction(_open);
             tb->addAction(_render);
+            tb->addSeparator();
+            tb->addAction(_options);
         }
 
         {main__central_c_l(QWidget, QGridLayout);
@@ -583,6 +593,8 @@ public:
 
         _exit->setShortcuts(QKeySequence::Quit);
         connect(_exit, &QAction::triggered, this, &MainWindowImpl::close);
+
+        connect(_options, &QAction::triggered, this, &MainWindowImpl::open_options);
 
         connect(_move_up, &QPushButton::clicked, this, &MainWindowImpl::move_up);
         connect(_move_down, &QPushButton::clicked, this, &MainWindowImpl::move_down);
@@ -696,6 +708,12 @@ public:
             render->setAttribute(Qt::WA_DeleteOnClose);
             render->show();
         }
+    }
+
+    void open_options() {
+        auto options = OptionsDialog::make(&_backend, this);
+        options->setAttribute(Qt::WA_DeleteOnClose);
+        options->show();
     }
 
 // impl QWidget

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -13,6 +13,7 @@
 #include <QLabel>
 #include <QMenuBar>
 #include <QPushButton>
+#include <QStatusBar>
 #include <QToolBar>
 
 // Model-view
@@ -490,6 +491,8 @@ public:
     QPushButton * _move_down;
     ChannelsView * _channels_view;
 
+    QLabel * _status;
+
     QAction * _open;
     QAction * _render;
     QAction * _exit;
@@ -584,6 +587,9 @@ public:
             }
         }
 
+        _status = new QLabel;
+        statusBar()->addWidget(_status);
+
         // Bind actions
         _open->setShortcuts(QKeySequence::Open);
         connect(_open, &QAction::triggered, this, &MainWindowImpl::on_open);
@@ -649,7 +655,12 @@ public:
     }
 
     void reload_settings() {
-        // TODO update status bar
+        if (_backend.is_file_loaded()) {
+            auto sample_rate = _backend.sample_rate();
+            _status->setText(tr("%1 Hz").arg(sample_rate));
+        } else {
+            _status->setText(tr("No file loaded"));
+        }
     }
 
     void move_up() {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -17,6 +17,7 @@ enum class StateUpdateFlag : uint32_t {
     All = ~(uint32_t)0,
     ChipsEdited = 0x1,
     FileReplaced = 0x10,
+    SettingsChanged = 0x20,
 };
 Q_DECLARE_FLAGS(StateUpdateFlags, StateUpdateFlag)
 Q_DECLARE_OPERATORS_FOR_FLAGS(StateUpdateFlags)
@@ -62,6 +63,7 @@ public:
 
     void file_replaced();
     void chips_changed();
+    void settings_changed();
 };
 
 class MainWindow : public QMainWindow {

--- a/src/options_dialog.cpp
+++ b/src/options_dialog.cpp
@@ -1,4 +1,5 @@
 #include "options_dialog.h"
+#include "mainwindow.h"  // TODO move StateTransaction to Backend
 #include "backend.h"
 #include "lib/layout_macros.h"
 
@@ -12,6 +13,7 @@
 
 class OptionsDialogImpl : public OptionsDialog {
 private:
+    MainWindow * _main;
     Backend * _backend;
     AppSettings _app;
 
@@ -22,8 +24,9 @@ private:
     QPushButton * _cancel;
 
 public:
-    OptionsDialogImpl(Backend * backend, QWidget * parent)
-        : OptionsDialog(parent)
+    OptionsDialogImpl(Backend * backend, MainWindow * parent_main)
+        : OptionsDialog(parent_main)
+        , _main(parent_main)
         , _backend(backend)
         , _app(_backend->settings().app_settings())
     {
@@ -72,7 +75,8 @@ public:
 
     void ok() {
         // Perhaps factor out into apply()?
-        _backend->settings_mut().set_app_settings(_app);
+        auto tx = _main->edit_unwrap();
+        _backend->settings_mut(tx).set_app_settings(_app);
         accept();
     }
 
@@ -81,6 +85,6 @@ public:
     }
 };
 
-OptionsDialog * OptionsDialog::make(Backend * backend, QWidget * parent) {
-    return new OptionsDialogImpl(backend, parent);
+OptionsDialog * OptionsDialog::make(Backend * backend, MainWindow * parent_main) {
+    return new OptionsDialogImpl(backend, parent_main);
 }

--- a/src/options_dialog.cpp
+++ b/src/options_dialog.cpp
@@ -1,0 +1,86 @@
+#include "options_dialog.h"
+#include "backend.h"
+#include "lib/layout_macros.h"
+
+#include <QCheckBox>
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QSpinBox>
+
+#include <QBoxLayout>
+#include <QFormLayout>
+
+class OptionsDialogImpl : public OptionsDialog {
+private:
+    Backend * _backend;
+    AppSettings _app;
+
+    QSpinBox * _sample_rate;
+    QCheckBox * _use_chip_rate;
+
+    QPushButton * _ok;
+    QPushButton * _cancel;
+
+public:
+    OptionsDialogImpl(Backend * backend, QWidget * parent)
+        : OptionsDialog(parent)
+        , _backend(backend)
+        , _app(_backend->settings().app_settings())
+    {
+        setModal(true);
+        setWindowTitle(tr("Options"));
+
+        // Hide contextual-help button in the title bar.
+        setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+        auto l = new QVBoxLayout(this);
+        {l__form(QFormLayout);
+            {form__label_w(tr("Default sample rate:"), QSpinBox);
+                _sample_rate = w;
+                w->setRange(1, 10'000'000);
+            }
+            {form__w(QCheckBox(tr("Use native chip sample rate")));
+                _use_chip_rate = w;
+            }
+        }
+        {l__w(QDialogButtonBox);
+            _ok = w->addButton(QDialogButtonBox::Ok);
+            _cancel = w->addButton(QDialogButtonBox::Cancel);
+        }
+
+        _sample_rate->setValue((int) _app.sample_rate);
+        connect(
+            _sample_rate, qOverload<int>(&QSpinBox::valueChanged),
+            this, [this](int sample_rate) {
+                _app.sample_rate = (uint32_t) sample_rate;
+            });
+
+        _use_chip_rate->setChecked(_app.use_chip_rate);
+        connect(
+            _use_chip_rate, &QCheckBox::toggled,
+            this, [this](bool use_chip_rate) {
+                _app.use_chip_rate = use_chip_rate;
+            });
+
+        connect(
+            _ok, &QPushButton::clicked,
+            this, &OptionsDialogImpl::ok);
+        connect(
+            _cancel, &QPushButton::clicked,
+            this, &OptionsDialogImpl::cancel);
+    }
+
+    void ok() {
+        // Perhaps factor out into apply()?
+        _backend->settings_mut().set_app_settings(_app);
+        accept();
+    }
+
+    void cancel() {
+        reject();
+    }
+};
+
+OptionsDialog * OptionsDialog::make(Backend * backend, QWidget * parent) {
+    return new OptionsDialogImpl(backend, parent);
+}

--- a/src/options_dialog.h
+++ b/src/options_dialog.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QDialog>
+
+class Backend;
+
+class OptionsDialog : public QDialog {
+    Q_OBJECT
+
+protected:
+    OptionsDialog(QWidget *parent = nullptr)
+        : QDialog(parent)
+    {}
+
+public:
+    static OptionsDialog * make(Backend * backend, QWidget * parent = nullptr);
+};
+

--- a/src/options_dialog.h
+++ b/src/options_dialog.h
@@ -3,6 +3,7 @@
 #include <QDialog>
 
 class Backend;
+class MainWindow;
 
 class OptionsDialog : public QDialog {
     Q_OBJECT
@@ -13,6 +14,6 @@ protected:
     {}
 
 public:
-    static OptionsDialog * make(Backend * backend, QWidget * parent = nullptr);
+    static OptionsDialog * make(Backend * backend, MainWindow * parent_main);
 };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,0 +1,90 @@
+#include "settings.h"
+
+#include <QSettings>
+
+#include <utility>  // std::move
+
+using std::move;
+
+struct SettingsData {
+    QSettings persist;
+    AppSettings app;
+};
+
+Settings::Settings(std::unique_ptr<SettingsData> data)
+    : _data(move(data))
+{}
+
+/// Read the current value from QSettings. If missing or invalid, overwrite it with
+/// default_.
+static uint32_t sync_u32(QSettings & settings, QString const& key, uint32_t default_) {
+    bool ok;
+    auto val = settings.value(key).toUInt(&ok);
+    if (ok) {
+        return val;
+    } else {
+        settings.setValue(key, default_);
+        return default_;
+    }
+}
+
+/// Read the current value from QSettings. If missing or invalid, overwrite it with
+/// default_.
+static bool sync_bool(QSettings & settings, QString const& key, bool default_) {
+    // When converting from QString to bool, QVariant's API makes it impossible to
+    // distinguish between valid and invalid boolean string literals. This makes it
+    // impossible to fallback to default_ when the settings contains an invalid string
+    // value.
+    auto var = settings.value(key);
+    if (var.isValid()) {
+        return var.toBool();
+    } else {
+        settings.setValue(key, default_);
+        return default_;
+    }
+}
+
+static const QString APP_USE_CHIP_RATE = QStringLiteral("app/use_chip_rate");
+static const QString APP_SAMPLE_RATE = QStringLiteral("app/sample_rate");
+
+/// Read the current settings from the system. If certain settings are missing or
+/// invalid, overwrite them with defaults.
+static void load_app_settings(SettingsData & data) {
+    QSettings & persist = data.persist;
+
+    data.app = AppSettings {
+        .use_chip_rate = sync_bool(persist, APP_USE_CHIP_RATE, true),
+        .sample_rate = sync_u32(persist, APP_SAMPLE_RATE, 44100),
+    };
+}
+
+Settings Settings::make() {
+    auto data = std::unique_ptr<SettingsData>(new SettingsData {
+        .persist = QSettings(
+            QSettings::IniFormat,
+            QSettings::UserScope,
+            QStringLiteral("qvgmsplit"),
+            QStringLiteral("qvgmsplit")),
+        .app = {},
+    });
+
+    load_app_settings(*data);
+
+    return Settings(move(data));
+}
+
+AppSettings const& Settings::app_settings() const {
+    return _data->app;
+}
+
+void Settings::set_app_settings(AppSettings app) {
+    // Even if settings are unchanged, persist the data. This makes changing settings
+    // in multiple simultaneous instances more predictable (last change wins), at least
+    // until we implement opening multiple windows from a single process.
+
+    _data->app = app;
+    _data->persist.setValue(APP_USE_CHIP_RATE, _data->app.use_chip_rate);
+    _data->persist.setValue(APP_SAMPLE_RATE, _data->app.sample_rate);
+}
+
+Settings::~Settings() = default;

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "lib/copy_move.h"
+
+#include <memory>
+#include <cstdint>
+
+struct SettingsData;
+
+struct AppSettings {
+    /// Whether to use the FM sampling rate (if present) rather than the user-selected
+    /// sampling rate.
+    bool use_chip_rate;
+
+    /// The fallback sampling rate to use if no FM chips are present.
+    uint32_t sample_rate;
+};
+
+class Settings {
+    std::unique_ptr<SettingsData> _data;
+
+private:
+    Settings(std::unique_ptr<SettingsData> data);
+
+public:
+    static Settings make();
+    ~Settings();
+
+    DEFAULT_MOVE(Settings)
+
+    AppSettings const& app_settings() const;
+    void set_app_settings(AppSettings app);
+};


### PR DESCRIPTION
This adds a system to autodetect sampling rate, as well as a settings dialog and storage system to toggle autodetection and pick the default rate.

- [x] Review code
- [x] Fix crash when changing settings with no file loaded
- [x] Replace "Assert on debug builds"
- [x] Test on Windows
	- [x] Check the .ini path is appropriate on Windows
- [x] Add status bar?
- [ ] ~~Add duration to status bar~~ deferred
- [x] Add options to toolbar
- [x] Test 2 app instances if settings interact (QSettings will, but we cache and never pull)
	- Settings don't interact between windows. The settings of a new window is determined by the last settings saved (I had to remove the check that skipped saving *locally* unchanged settings).
- [x] Add separate functions to initialize settings on startup (if !contains) and write settings on save (always).
- [x] Test settings initialization on Linux

Fixes #30. See #17.