### PR TITLE
Don't reset selections when failing to load file

### DIFF
--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -661,7 +661,7 @@ Settings & Backend::settings_mut(StateTransaction & tx) {
 
 Backend::~Backend() = default;
 
-QString Backend::load_path(QString const& path) {
+QString Backend::load_path(StateTransaction & tx, QString const& path) {
     if (is_rendering()) {
         return tr("Cannot load path while rendering");
     }
@@ -691,6 +691,10 @@ QString Backend::load_path(QString const& path) {
         if (result.is_err()) {
             return move(result.err_value());
         }
+
+        // We must call tx.file_replaced() (begin resetting chip/channel models) before
+        // overwriting _metadata (which holds the chip/channel lists).
+        tx.file_replaced();
 
         _file_data = move(file_data);
         _metadata = move(result.value());

--- a/src/backend.h
+++ b/src/backend.h
@@ -87,7 +87,7 @@ public:
     Settings & settings_mut(StateTransaction & tx);
 
     /// If non-empty, holds error message.
-    [[nodiscard]] QString load_path(QString const& path);
+    [[nodiscard]] QString load_path(StateTransaction & tx, QString const& path);
     /// If non-empty, holds error message.
     [[nodiscard]] QString reload_settings();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -605,10 +605,9 @@ public:
         connect(_move_up, &QPushButton::clicked, this, &MainWindowImpl::move_up);
         connect(_move_down, &QPushButton::clicked, this, &MainWindowImpl::move_down);
 
+        update_file_status();
         if (!path.isEmpty()) {
             load_path(std::move(path));
-        } else {
-            update_file_status();
         }
     }
 
@@ -620,12 +619,7 @@ public:
     void load_path(QString file_path) {
         auto tx = edit_unwrap();
 
-        // StateTransaction::file_replaced() must be called before the chips/channels
-        // change. Backend::load_path() overwrites the chips/channels, so we must call
-        // file_replaced() first.
-        tx.file_replaced();
-        // TODO make Backend::load_path() accept StateTransaction &?
-        auto err = _backend.load_path(file_path);
+        auto err = _backend.load_path(tx, file_path);
 
         if (!err.isEmpty()) {
             show_error(tr("Error loading file \"%1\":<br>%2").arg(file_path, err));


### PR DESCRIPTION
- [x] Remove irrelevant commits
- [x] Fix bug: status bar empty when loading invalid file

`MainWindow::load_path()` doesn't accept a `StateTransaction`. Doing so would burden all its callers. This causes a bit of duplicated work on startup, but I don't care.

we don't send an "everything changed" event on startup. Maybe we should.