### PR TITLE
Fix incorrect target_link_libraries() discovered in Meson port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ endif()
 target_compile_options(qvgmsplit PRIVATE "${options}")
 target_link_libraries(qvgmsplit PRIVATE
     ${Qt}::Widgets
-    vgm-audio vgm-player vgm-utils
+    vgm-emu vgm-player vgm-utils
     fmt GSL stx
 )
 


### PR DESCRIPTION
We call functions in vgm-emu, but forgot to include it. It only compiles in CMake because the headers were somehow visible, and the static library was included indirectly. It fails to link on Meson. Let's add it anyway to be safe.

I removed vgm-audio becauase we don't use it (real-time playback).